### PR TITLE
KockaLogger v1.1.1

### DIFF
--- a/include/io.js
+++ b/include/io.js
@@ -37,8 +37,9 @@ class IO {
         ) {
             return;
         }
-        options.format = 'json';
         options.action = 'query';
+        options.cb = Date.now();
+        options.format = 'json';
         return http({
             headers: {
                 'User-Agent': USER_AGENT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "description": "The time has come.",
     "keywords": [
         "wikia",

--- a/parser/log.js
+++ b/parser/log.js
@@ -339,13 +339,15 @@ class LogMessage extends RCMessage {
      * @private
      */
     _rights(res) {
+        const regex = res.slice(0, 3);
         this.target = res.shift();
         const oldgroups = res.shift(),
               newgroups = res.shift();
         if (!oldgroups || !newgroups) {
             this._error(
                 'missinggroups',
-                'Groups missing from rights log entry.'
+                'Groups missing from rights log entry.',
+                {regex}
             );
         }
         if (oldgroups) {

--- a/parser/rc.js
+++ b/parser/rc.js
@@ -47,9 +47,9 @@ class RCMessage extends Message {
     _getParentThread() {
         if (!this._cached.parentThread) {
             this._cached.parentThread = this.page
-                .split('/')
+                .split('/@comment-')
                 .slice(0, 2)
-                .join('/');
+                .join('/@comment-');
         }
         return this._cached.parentThread;
     }


### PR DESCRIPTION
## Fixed
- `rcerror` and `logparsefail` errors are now less common, because the client attempts to fix issues related to a space missing between concatenated message parts.
    - This does not completely get rid of these errors, as parsing logs whose custom messages have not yet been fetched with a space introduced in the middle will still throw this error, but this should at most happen only once per wiki with customized log messages.
- Added a cachebuster parameter to `IO#query` in an attempt to make the API not use a cached response when querying for revision IDs (and therefore not return an error due to nonexistent revision IDs).
- Split the thread title by `/@comment-` instead of just `/` to fix an issue with board names that contain slashes in them.

## New
- Added more information around missing groups, such as regex parsing results.