### PR TITLE
KockaLogger v1.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.2",
+    "version": "1.1.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "The time has come.",
     "keywords": [
         "wikia",

--- a/parser/msg.js
+++ b/parser/msg.js
@@ -65,7 +65,6 @@ class Message {
         this.error = false;
         delete this.errmsg;
         delete this.errdetails;
-        delete this._cached;
         delete this._client;
         delete this._resolve;
         delete this._reject;

--- a/parser/rc.js
+++ b/parser/rc.js
@@ -28,6 +28,13 @@ class RCMessage extends Message {
         res.shift();
     }
     /**
+     * Cleans up after a failed fetch.
+     */
+    cleanup() {
+        super.cleanup();
+        this._cached = {};
+    }
+    /**
      * Trims the unnecessary character off the summary
      * @param {String} summary Summary to trim
      * @returns {String} Trimmed summary


### PR DESCRIPTION
## Fixed
- `Message#cleanup()` was cleaning up... too much and caused a few crashes.
- Updated version in the lockfile.