### PR TITLE
KockaLogger v1.1.6

### DIFF
--- a/formats/discussions/main.js
+++ b/formats/discussions/main.js
@@ -41,8 +41,7 @@ class DiscussionsFormat extends Format {
             embeds: [
                 {
                     author: {
-                        // TODO: Change when HTTPS is released globally.
-                        name: `${msg.user} [${msg.wiki}]`,
+                        name: `${msg.user} [${util.shorturl(msg.wiki, msg.language, msg.domain)}]`,
                         url: `${util.url(msg.wiki, msg.language, msg.domain)}/wiki/Special:Contribs/${util.encode(msg.user)}`
                     },
                     color: COLOR[msg.dtype],

--- a/formats/discussions/main.js
+++ b/formats/discussions/main.js
@@ -18,7 +18,7 @@ const COLOR = {
     post: 0x00FF00,
     report: 0xFF0000,
     thread: 0xFFFF00
-};
+}, P_REGEX = /^<p>(.*)(?:<\/p>)?$/;
 
 /**
  * Main class.
@@ -46,7 +46,7 @@ class DiscussionsFormat extends Format {
                         url: `${util.url(msg.wiki, msg.language, msg.domain)}/wiki/Special:Contribs/${util.encode(msg.user)}`
                     },
                     color: COLOR[msg.dtype],
-                    description: msg.snippet,
+                    description: msg.snippet.trim().replace(P_REGEX, '$1'),
                     title: msg.title ?
                         `${msg.title} [${util.cap(msg.dtype)} ${msg.action}]` :
                         `${util.cap(msg.dtype)} ${msg.action}`,

--- a/formats/logger/main.js
+++ b/formats/logger/main.js
@@ -501,7 +501,6 @@ class Logger extends Format {
      * @param {String} domain Domain of the wiki
      * @param {String} page Page to link to
      * @returns {String} Markdown link
-     * @todo Fix for new language paths
      */
     _wikiLink(text, wiki, lang, domain, page) {
         return this._link(text, wiki, lang, domain, `wiki/${util.encode(page)}`);

--- a/formats/logger/main.js
+++ b/formats/logger/main.js
@@ -16,7 +16,8 @@ const net = require('net'),
 /**
  * Constants.
  */
-const ACM = /<ac(_|$)(m|$)(e|$)(t|$)(a|$)(d|$)(a|$)(t|$)(a|$)( |$)(t|$)(i|$)(t|$)(l|$)(e|$)(=|$)("|$).*"$/;
+const ACM = /<ac(_|$)(m|$)(e|$)(t|$)(a|$)(d|$)(a|$)(t|$)(a|$)( |$)(t|$)(i|$)(t|$)(l|$)(e|$)(=|$)("|$).*"$/,
+      P_REGEX = /^<p>(.*)(?:<\/p>)?$/;
 
 /**
  * Logger format's class.
@@ -377,7 +378,7 @@ class Logger extends Format {
             m.reply,
             m.size,
             util.escape(m.category),
-            m.snippet
+            m.snippet.trim().replace(P_REGEX, '$1')
         );
     }
     /* eslint-disable max-statements */

--- a/include/util.js
+++ b/include/util.js
@@ -35,6 +35,21 @@ class Util {
         return `https://${wiki}.${domain}`;
     }
     /**
+     * Returns a Fandom wiki URL without the protocol.
+     * @param {String} wiki Subdomain of the wiki
+     * @param {String} lang Language of the wiki
+     * @param {String} domain Domain of the wiki
+     * @returns {String} URL to the requested wiki (protocol-less)
+     * @static
+     */
+    static shorturl(wiki, lang, domain) {
+        let url = `${wiki}.${domain}`;
+        if (lang && lang !== 'en') {
+            url = `${url}/${lang}`;
+        }
+        return url;
+    }
+    /**
      * Makes Markdown safe to post through a webhook.
      * @param {String} text Markdown to escape
      * @returns {String} Escaped parameter

--- a/messages/main.js
+++ b/messages/main.js
@@ -418,7 +418,6 @@ class Loader {
      * @param {String} domain Domain of the wiki
      * @param {Object} data Custom messages for the wiki
      * @param {Function} callback Callback function after the update
-     * @todo DRY?
      */
     updateCustom(wiki, language, domain, data, callback) {
         if (!this._caches.custom) {

--- a/messages/map.js
+++ b/messages/map.js
@@ -151,10 +151,9 @@ const MAPPING = {
      * Transforms the unblock log entry
      * @param {String} e Log entry
      * @returns {String} Regex'd log entry
-     * @todo Edge case: User has : in username
      */
     'unblocklogentry': e => `^${util.escapeRegex(e)
-        .replace('\\$1', '[^:]+:([^:]+)')
+        .replace('\\$1', '[^:]+:(.+)')
     }(?:${REASON})?$`,
     /**
      * Transforms the unprotect log entry

--- a/messages/map.js
+++ b/messages/map.js
@@ -1,7 +1,8 @@
 /**
  * map.js
  *
- * @todo Kill me now
+ * Maps MediaWiki system messages to regular expressions later used during
+ * IRC message parsing.
  */
 'use strict';
 

--- a/messages/map.js
+++ b/messages/map.js
@@ -137,7 +137,7 @@ const MAPPING = {
      */
     'protectedarticle': e => `^${colorLink(util.escapeRegex(e))
         .replace('\\$1', '([^\x03]+)')
-    }((?: (?:\\u200E|\\u200F)\\[(?:edit|move|upload|create|everything)=\\w+\\] \\([^\\u200E\\u200F]+\\)){1,3})(?:${REASON})?$`,
+    }((?: (?:\\u200E|\\u200F)\\[(?:edit|move|upload|create|everything)=\\w+\\] \\([^\\u200E\\u200F)]+\\)){1,3})(?:${REASON})?$`,
     /**
      * Transforms the rights log entry
      * @param {String} e Log entry

--- a/modules/logger/main.js
+++ b/modules/logger/main.js
@@ -168,7 +168,6 @@ class Logger extends Module {
         this._logger.close(callback);
         this._wikis.forEach(wiki => wiki.kill(callback));
         return this._wikis.length + 1;
-        // TODO: Clean up loggers in wikis.
     }
 }
 

--- a/modules/newusers/main.js
+++ b/modules/newusers/main.js
@@ -391,7 +391,10 @@ class NewUsers extends Module {
         }
         this._transport.execute({
             content: `\`!report p ${
-                wiki === 'www' || wiki === 'community' ? 'c' : wiki
+                wiki === 'www' ||
+                wiki === 'community' ?
+                    'c' :
+                    util.shorturl(wiki, language, domain)
             } ${info.username}\``,
             embeds: [message]
         });

--- a/modules/vandalism/main.js
+++ b/modules/vandalism/main.js
@@ -12,7 +12,8 @@ const net = require('net'),
       Module = require('../module.js'),
       Format = require('../../formats/logger/main.js'),
       Discord = require('../../transports/discord/main.js'),
-      Logger = require('../../include/log.js');
+      Logger = require('../../include/log.js'),
+      util = require('../../include/util.js');
 
 /**
  * Constants.
@@ -99,11 +100,7 @@ class Vandalism extends Module {
                     typeof formatted === 'object' &&
                     typeof formatted.content === 'string'
                 ) {
-                    let wiki = `${message.wiki}.${message.domain}`;
-                    if (message.language && message.language !== 'en') {
-                        wiki = `${wiki}/${message.language}`;
-                    }
-                    formatted.content = `[${wiki}] ${formatted.content}`;
+                    formatted.content = `[${util.shorturl(message.wiki, message.language, message.domain)}] ${formatted.content}`;
                     this._transport.execute(formatted);
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -294,9 +294,9 @@
             "dev": true
         },
         "eslint": {
-            "version": "5.15.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
-            "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
+            "version": "5.15.3",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
+            "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -305,7 +305,7 @@
                 "cross-spawn": "^6.0.5",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
-                "eslint-scope": "^4.0.2",
+                "eslint-scope": "^4.0.3",
                 "eslint-utils": "^1.3.1",
                 "eslint-visitor-keys": "^1.0.0",
                 "espree": "^5.0.1",
@@ -352,9 +352,9 @@
             }
         },
         "eslint-scope": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
-            "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+            "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
             "dev": true,
             "requires": {
                 "esrecurse": "^4.1.0",
@@ -665,18 +665,18 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "strip-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -744,9 +744,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-            "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -1300,29 +1300,29 @@
                     }
                 },
                 "ansi-regex": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "string-width": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-                    "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
                         "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.0.0"
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.0.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "The time has come.",
     "keywords": [
         "wikia",
@@ -31,6 +31,6 @@
         "request-promise-native": ">=1.0.7"
     },
     "devDependencies": {
-        "eslint": ">=5.15.1"
+        "eslint": ">=5.15.3"
     }
 }

--- a/parser/edit.js
+++ b/parser/edit.js
@@ -36,6 +36,10 @@ class EditMessage extends RCMessage {
         this.wiki = res.shift();
         this.domain = res.shift();
         this.language = res.shift() || 'en';
+        if (this.language === 'wiki') {
+            // Hack because www.wikia.com has no /wiki in path.
+            this.language = 'en';
+        }
         this.params = {};
         res.shift().split('&').forEach(this._parseParam, this);
         this.user = res.shift();

--- a/parser/log.js
+++ b/parser/log.js
@@ -348,7 +348,7 @@ class LogMessage extends RCMessage {
         } else if (this.action !== 'unprotect') {
             this.level = [];
             const level = res.shift(),
-                  regex = / \u200E\[(edit|move|upload|create|everything)=\w+\] \(([^\u200E]+)\)(?: \u200E|$|:)/g;
+                  regex = / \u200E\[(edit|move|upload|create|everything)=\w+\] \(([^\u200E)]+)\)(?: \u200E|$|:)/g;
             let res2 = null;
             do {
                 res2 = regex.exec(level);

--- a/parser/log.js
+++ b/parser/log.js
@@ -104,9 +104,11 @@ class LogMessage extends RCMessage {
             this._advanced();
         }
     }
+    /* eslint-disable max-statements */
     /**
      * Advanced log parsing.
      * @private
+     * @todo Split this up.
      */
     _advanced() {
         // If there's a handler for this action, attempt to handle it.
@@ -123,6 +125,15 @@ class LogMessage extends RCMessage {
                     }
                 } else {
                     res = this._i18n();
+                    // action = 'restore' can have two meanings.
+                    if (
+                        !res &&
+                        this.log === 'move' &&
+                        this.action === 'restore'
+                    ) {
+                        this.action = 'move_redir';
+                        res = this._i18n();
+                    }
                 }
                 if (!res) {
                     this._error(
@@ -145,6 +156,7 @@ class LogMessage extends RCMessage {
             );
         }
     }
+    /* eslint-enable max-statements */
     /**
      * Attempts to parse the summary based on regular expressions
      * generated from i18n MediaWiki messages.

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -19,7 +19,8 @@ const DiscussionsMessage = require('./discussions.js'),
  * Constants.
  */
 const EDIT_REGEX = /^\x0314\[\[\x0307([^\]]+)\x0314\]\]\x034 ([!NBM]*)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?index\.php\?(\S+)\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03 \(\x02?(\+|-)(\d+)\x02?\) \x0310(.*)$/,
-      LOG_REGEX = /^\x0314\[\[\x0307[^:]+:Log\/([^\x03]+)\x0314\]\]\x034 ([^\x03]+)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?wiki\/[^:]+:Log\/[^\x03]+\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03\s{2}\x0310(.*)$/;
+      // NOTE: \s{2} is \s{1,2} due to overflow space removal.
+      LOG_REGEX = /^\x0314\[\[\x0307[^:]+:Log\/([^\x03]+)\x0314\]\]\x034 ([^\x03]+)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?(?:wiki\/)?[^:]+:Log\/[^\x03]+\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03\s{1,2}\x0310(.*)$/;
 
 /**
  * Class for parsing messages received from WikiaRC.


### PR DESCRIPTION
## Fixed
- KockaLogger should no longer be throwing loads of "IRC errors" when people ProtectSite without a summary.
- Callback generation should hopefully be gone from KockaLogger thanks to `Function.prototype.bind`.
- Unblock log entries for IPv6 users should no longer throw parsing errors.
- Logs on `www.wikia.com` should no longer throw parsing errors.
- Removed some outdated todos.

## New
- `<p>` tags are stripped from Discussions post snippets (closes #29).
- `newusers` module should be retrying requests that fail and logging full wiki URL without the protocol in the report command.

## Notes
- Regenerate messages after the release.