### PR TITLE
KockaLogger v1.1.7

### DIFF
--- a/formats/logger/main.js
+++ b/formats/logger/main.js
@@ -338,7 +338,7 @@ class Logger extends Format {
                     m.reason
                 );
             case 'abusefilter':
-                return this._msg('abusefilter', w, l, m.user, m.id, m.diff);
+                return this._msg('abusefilter', w, l, d, m.user, m.id, m.diff);
             case 'wikifeatures':
                 return this._msg(
                     'wikifeatures',

--- a/modules/logger/filter.js
+++ b/modules/logger/filter.js
@@ -19,6 +19,9 @@ class Filter {
             this._transport = typeof config.transport === 'string' ?
                 config.transport :
                 'default';
+            this._negation = typeof config.negation === 'boolean' ?
+                config.negation :
+                false;
             if (config.namespaces instanceof Array) {
                 this._namespaceFilter = config.namespaces;
             }
@@ -42,7 +45,7 @@ class Filter {
      */
     execute(message) {
         try {
-            if (this._func(message)) {
+            if (this._func(message) !== this._negation) {
                 return this._transport;
             }
         } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -136,9 +136,9 @@
             }
         },
         "callsites": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-            "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
         "caseless": {
@@ -294,13 +294,13 @@
             "dev": true
         },
         "eslint": {
-            "version": "5.15.3",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
-            "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+            "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "ajv": "^6.9.1",
+                "ajv": "^6.10.0",
                 "chalk": "^2.1.0",
                 "cross-spawn": "^6.0.5",
                 "debug": "^4.0.1",
@@ -308,18 +308,19 @@
                 "eslint-scope": "^4.0.3",
                 "eslint-utils": "^1.3.1",
                 "eslint-visitor-keys": "^1.0.0",
-                "espree": "^5.0.1",
+                "espree": "^6.0.0",
                 "esquery": "^1.0.1",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
+                "glob-parent": "^3.1.0",
                 "globals": "^11.7.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "inquirer": "^6.2.2",
-                "js-yaml": "^3.12.0",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.3.0",
                 "lodash": "^4.17.11",
@@ -327,7 +328,6 @@
                 "mkdirp": "^0.5.1",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
                 "progress": "^2.0.0",
                 "regexpp": "^2.0.1",
                 "semver": "^5.5.1",
@@ -374,9 +374,9 @@
             "dev": true
         },
         "espree": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-            "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
+            "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.7",
@@ -498,9 +498,9 @@
             }
         },
         "flatted": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-            "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
             "dev": true
         },
         "forever-agent": {
@@ -547,9 +547,9 @@
             }
         },
         "glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -560,10 +560,31 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                }
+            }
+        },
         "globals": {
-            "version": "11.11.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
         "har-schema": {
@@ -638,15 +659,15 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "inquirer": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-            "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
+            "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
             "dev": true,
             "requires": {
                 "ansi-escapes": "^3.2.0",
@@ -660,7 +681,7 @@
                 "run-async": "^2.2.0",
                 "rxjs": "^6.4.0",
                 "string-width": "^2.1.0",
-                "strip-ansi": "^5.0.0",
+                "strip-ansi": "^5.1.0",
                 "through": "^2.3.6"
             },
             "dependencies": {
@@ -704,11 +725,26 @@
                 }
             }
         },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
             "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
         },
         "is-promise": {
             "version": "2.1.0",
@@ -744,9 +780,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-            "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -863,9 +899,9 @@
             }
         },
         "ms": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
         "mute-stream": {
@@ -963,24 +999,24 @@
             "dev": true
         },
         "parent-module": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-            "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
         },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
-        },
-        "path-is-inside": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
             "dev": true
         },
         "path-key": {
@@ -1148,9 +1184,9 @@
             }
         },
         "rxjs": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-            "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -1167,9 +1203,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
         "seq-queue": {
@@ -1276,9 +1312,9 @@
             }
         },
         "table": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-            "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+            "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
             "dev": true,
             "requires": {
                 "ajv": "^6.9.1",
@@ -1358,9 +1394,9 @@
             }
         },
         "tslib": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
             "dev": true
         },
         "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "kocka-logger",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "The time has come.",
     "keywords": [
         "wikia",
@@ -31,6 +31,6 @@
         "request-promise-native": ">=1.0.7"
     },
     "devDependencies": {
-        "eslint": ">=5.15.3"
+        "eslint": ">=6.0.1"
     }
 }

--- a/parser/edit.js
+++ b/parser/edit.js
@@ -36,10 +36,6 @@ class EditMessage extends RCMessage {
         this.wiki = res.shift();
         this.domain = res.shift();
         this.language = res.shift() || 'en';
-        if (this.language === 'wiki') {
-            // Hack because www.wikia.com has no /wiki in path.
-            this.language = 'en';
-        }
         this.params = {};
         res.shift().split('&').forEach(this._parseParam, this);
         this.user = res.shift();

--- a/parser/log.js
+++ b/parser/log.js
@@ -344,7 +344,7 @@ class LogMessage extends RCMessage {
         } else if (this.action !== 'unprotect') {
             this.level = [];
             const level = res.shift(),
-                  regex = / \u200E\[(edit|move|upload|create|everything)=\w+\] \(([^\u200E]+)\)(?: \u200E|$|:)/g;
+                  regex = / \u200E\[(edit|move|upload|create|everything)=(\w+)\] \(([^\u200E]+)\)(?: \u200E|$|:)/g;
             let res2 = null;
             do {
                 res2 = regex.exec(level);

--- a/parser/log.js
+++ b/parser/log.js
@@ -15,7 +15,7 @@ const RCMessage = require('./rc.js'),
 /**
  * Constants.
  */
-const AF_REGEX = /https?:\/\/[a-z0-9-.]+\.(?:fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:[a-z-]+\/)?(?:wiki\/)?[^:]+:[^/]+\/(\d+).*\(https?:\/\/[a-z0-9-.]+\.(?:fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:[a-z-]+\/)?(?:wiki\/)?[^:]+:[^/]+\/history\/\d+\/diff\/prev\/(\d+)\)$/,
+const AF_REGEX = /https?:\/\/[a-z0-9-.]+\.(?:fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:[a-z-]+\/)?wiki\/?[^:]+:[^/]+\/(\d+).*\(https?:\/\/[a-z0-9-.]+\.(?:fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:[a-z-]+\/)?wiki\/?[^:]+:[^/]+\/history\/\d+\/diff\/prev\/(\d+)\)$/,
 BLOCK_FLAGS = [
     'angry-autoblock',
     'anononly',
@@ -94,10 +94,6 @@ class LogMessage extends RCMessage {
         this.wiki = res.shift();
         this.domain = res.shift();
         this.language = res.shift() || 'en';
-        if (this.language === 'wiki') {
-            // Hack because www.wikia.com has no /wiki in path.
-            this.language = 'en';
-        }
         this.user = res.shift();
         this._summary = this._trimSummary(res.shift());
         if (this.log !== 'useravatar' || this.action !== 'avatar_chn') {

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -20,7 +20,7 @@ const DiscussionsMessage = require('./discussions.js'),
  */
 const EDIT_REGEX = /^\x0314\[\[\x0307([^\]]+)\x0314\]\]\x034 ([!NBM]*)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?index\.php\?(\S+)\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03 \(\x02?(\+|-)(\d+)\x02?\) \x0310(.*)$/,
       // NOTE: \s{2} is \s{1,2} due to overflow space removal.
-      LOG_REGEX = /^\x0314\[\[\x0307[^:]+:Log\/([^\x03]+)\x0314\]\]\x034 ([^\x03]+)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?(?:wiki\/)?[^:]+:Log\/[^\x03]+\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03\s{1,2}\x0310(.*)$/;
+      LOG_REGEX = /^\x0314\[\[\x0307[^:]+:Log\/([^\x03]+)\x0314\]\]\x034 ([^\x03]+)\x0310 \x0302https?:\/\/([a-z0-9-.]+)\.(fandom\.com|wikia\.(?:com|org)|(?:wikia|fandom)-dev\.(?:com|us|pl))\/(?:([a-z-]+)\/)?wiki\/[^:]+:Log\/[^\x03]+\x03 \x035\*\x03 \x0303([^\x03]+)\x03 \x035\*\x03\s{1,2}\x0310(.*)$/;
 
 /**
  * Class for parsing messages received from WikiaRC.


### PR DESCRIPTION
## Fixed
- AbuseFilter logs are no longer weird.
- Protection logs no longer display `undefined` as the expiry time and the expiry time as the protection level.
- GitHub should no longer complain about security issues.
- An exception for logs on `www.wikia.com` introduced in #31 has been removed (following the wiki's closure).

## New
- Logger filters now allow negation (for example, not relaying messages that otherwise match the filter).
- A new user log has been implemented to replace the old one.