### PR TITLE
Get wiki ID for UCP wikis

### DIFF
--- a/modules/logger/main.js
+++ b/modules/logger/main.js
@@ -93,7 +93,8 @@ class Logger extends Module {
                 'general',
                 'namespaces',
                 'statistics',
-                'wikidesc'
+                'wikidesc',
+                'variables'
             ].join('|')
         }).then(function(d) {
             if (

--- a/modules/logger/wiki.js
+++ b/modules/logger/wiki.js
@@ -157,7 +157,7 @@ class Wiki {
      * @todo Use the statistics somehow
      */
     setData(data) {
-        this._id = Number(data.wikidesc.id);
+        this._id = Number(data.variables.filter((variable) => variable.id === 'wgCityId')[0]['*']);
         this._sitename = data.general.sitename;
         this._path = data.general.articlepath;
         this._namespaces = {};


### PR DESCRIPTION
## Fixed
- Obtain wiki ID from 'variables' as 'wikidesc' is unavailable on UCP: [example API call](https://ucp.fandom.com/api.php?action=query&meta=siteinfo&siprop=general|namespaces|statistics|wikidesc|variables&format=json)

## Pings
@KockaAdmiralac
