### PR TITLE
Fix protect logs regex

### DIFF
--- a/parser/log.js
+++ b/parser/log.js
@@ -268,13 +268,14 @@ class LogMessage extends RCMessage {
      * @private
      */
     _protect(res) {
-        this.page = res.shift();
+        const pageWithLevels = res.shift();
+        this.page = pageWithLevels.replace(/ \u200E.*$/g, '');
         if (this.action === 'move_prot') {
             this.target = res.shift();
         } else if (this.action !== 'unprotect') {
             this.level = [];
-            const level = res.shift(),
-                  regex = / \u200E\[(edit|move|upload|create|comment|everything)=(\w+)\] \(([^\u200E]+)\)(?: \u200E|$|:)/g;
+            const level = pageWithLevels + res.shift(),
+                  regex = /\u200E\[(edit|move|upload|create|comment|everything)=(\w+)\] \(([^\u200E]+)\)+/g;
             let res2 = null;
             do {
                 res2 = regex.exec(level);


### PR DESCRIPTION
## Fixed
- Protect and reprotect logs as the format changed (the duration/settings are within the page title)

![image](https://user-images.githubusercontent.com/5524849/159105114-b2d63cb0-31f7-46f2-822e-aec09f4138e6.png)

## Pings
@KockaAdmiralac
